### PR TITLE
Reestrutura visual de contas em cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -34,7 +34,7 @@
     --color-primary-200: #ceeede;
     --color-primary-300: #7cc1a0;
     --color-primary-400: #3db07e;
-    --color-primary-500: #07a362;
+    --color-primary-500: #009900;
     --color-primary-600: #068d54;
     --color-primary-700: #053f27;
     
@@ -43,7 +43,7 @@
     --color-background-alt: #f5f5f5;
     --color-surface: #ffffff;
     --color-border: #dee2e6;
-    --color-text: #0a0a0a;
+    --color-text: #0D0D0D;
     --color-text-muted: #6c757d;
     
     /* Contextual Colors */
@@ -1630,6 +1630,7 @@
     width: 100%;
     margin: 0 auto;
     padding: var(--spacing-5);
+    cursor: pointer;
     transition: all var(--transition-duration-normal) var(--transition-timing);
   }
   
@@ -1675,6 +1676,13 @@
     color: var(--color-text-muted);
     font-size: var(--font-size-sm);
     margin: 0;
+  }
+
+  .account-card__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--spacing-3);
+    margin-top: var(--spacing-4);
   }
 
   /* Grade de contas em três colunas */

--- a/pages/contas.php
+++ b/pages/contas.php
@@ -117,7 +117,7 @@ $count = count($contas);
     </div>
 </div>
 
-<!-- Tabela de Contas -->
+<!-- Lista de Contas -->
 <div class="transaction-table-container fade-in-up">
     <div class="p-4 flex justify-between items-center border-bottom">
         <h4 class="font-semibold m-0">Suas Contas</h4>
@@ -129,100 +129,65 @@ $count = count($contas);
         </div>
     </div>
 
-    <table class="table transaction-table mt-3">
-        <thead>
-            <tr>
-                <th class="text-left">Nome</th>
-                <th class="text-center">Tipo</th>
-                <th class="text-center">Saldo</th>
-                <th class="text-center">Instituição</th>
-                <th class="text-center" width="15%">Ações</th>
-            </tr>
-        </thead>
-        <tbody id="tabelaContas">
-            <?php
-            if (empty($contas)) {
-                echo '<tr><td colspan="5">';
-                echo '<div class="empty-state my-5">';
-                echo '<i class="fas fa-wallet empty-state__icon"></i>';
-                echo '<h3 class="empty-state__title">Nenhuma conta encontrada</h3>';
-                echo '<p class="empty-state__description">';
-                echo 'Comece a registrar suas contas financeiras para visualizá-las aqui.';
-                echo '</p>';
-                // Aqui foi corrigido de "#contaModal" para "#modalNovaConta"
-                echo '<button class="btn btn-primary btn-icon" data-modal-open="#modalNovaConta">';
-                echo '<i class="fas fa-plus me-2"></i> Criar Primeira Conta';
-                echo '</button>';
-                echo '</div>';
-                echo '</td></tr>';
-            } else {
-                $delay = 100;
-                foreach ($contas as $conta) {
-                    // Determina as classes para tipo de conta
-                    $tipoBadgeClass = 'badge-info';
-                    if ($conta['Tipo'] === 'Corrente') {
-                        $tipoBadgeClass = 'badge-primary';
-                    } elseif ($conta['Tipo'] === 'Poupança') {
-                        $tipoBadgeClass = 'badge-income';
-                    } elseif ($conta['Tipo'] === 'Cartão de Crédito') {
-                        $tipoBadgeClass = 'badge-expense';
-                    }
-
-                    $icone = obterIconeTipoConta($conta['Tipo']);
-
-                    echo "<tr>";
-                        // Coluna Nome (alinhado à esquerda)
-                        echo "<td class=\"text-left\">"
-                            . htmlspecialchars($conta['Nome']) .
-                             "</td>";
-
-                        // Coluna Tipo (centralizado)
-                        echo "<td class=\"text-center\">"
-                            . "<span class=\"badge {$tipoBadgeClass}\">"
-                            . "<i class=\"fas {$icone} me-1\"></i>"
-                            . htmlspecialchars($conta['Tipo'])
-                            . "</span>"
-                            . "</td>";
-
-                        // Coluna Saldo (centralizado, fonte semibold)
-                        echo "<td class=\"text-center font-semibold\">"
-                            . "R$ " . number_format($conta['Saldo'], 2, ',', '.')
-                            . "</td>";
-
-                        // Coluna Instituição (centralizado)
-                        echo "<td class=\"text-center\">"
-                            . htmlspecialchars($conta['Instituicao'])
-                            . "</td>";
-
-                        // Coluna Ações (centralizado)
-                        echo "<td class=\"text-center\">"
-                            . "<div class=\"flex justify-center gap-2\">"
-                                // Botão de editar
-                                . "<button class=\"btn-action edit\" title=\"Editar\" data-modal-open=\"#editarContaModal\" "
-                                . "data-id=\"" . $conta['ID_Conta'] . "\" "
-                                . "data-nome=\"" . htmlspecialchars($conta['Nome']) . "\" "
-                                . "data-tipo=\"" . $conta['Tipo'] . "\" "
-                                . "data-saldo=\"" . $conta['Saldo'] . "\" "
-                                . "data-instituicao=\"" . htmlspecialchars($conta['Instituicao']) . "\">"
-                                    . "<i class=\"fas fa-edit\"></i>"
-                                . "</button>"
-
-                                // Botão de excluir
-                                . "<button class=\"btn-action delete\" title=\"Excluir\" data-modal-open=\"#excluirContaModal\" "
-                                . "data-id=\"" . $conta['ID_Conta'] . "\" "
-                                . "data-nome=\"" . htmlspecialchars($conta['Nome']) . "\">"
-                                    . "<i class=\"fas fa-trash-alt\"></i>"
-                                . "</button>"
-                            . "</div>"
-                            . "</td>";
-                    echo "</tr>";
-
-                    $delay += 100;
+    <div id="contasGrid" class="mt-3">
+        <?php
+        if (empty($contas)) {
+            echo '<div class="empty-state my-5">';
+            echo '<i class="fas fa-wallet empty-state__icon"></i>';
+            echo '<h3 class="empty-state__title">Nenhuma conta encontrada</h3>';
+            echo '<p class="empty-state__description">';
+            echo 'Comece a registrar suas contas financeiras para visualizá-las aqui.';
+            echo '</p>';
+            echo '<button class="btn btn-primary btn-icon" data-modal-open="#modalNovaConta">';
+            echo '<i class="fas fa-plus me-2"></i> Criar Primeira Conta';
+            echo '</button>';
+            echo '</div>';
+        } else {
+            $delay = 100;
+            foreach ($contas as $conta) {
+                $tipoBadgeClass = 'badge-info';
+                if ($conta['Tipo'] === 'Corrente') {
+                    $tipoBadgeClass = 'badge-primary';
+                } elseif ($conta['Tipo'] === 'Poupança') {
+                    $tipoBadgeClass = 'badge-income';
+                } elseif ($conta['Tipo'] === 'Cartão de Crédito') {
+                    $tipoBadgeClass = 'badge-expense';
                 }
+
+                $icone = obterIconeTipoConta($conta['Tipo']);
+
+                echo '<div class="account-card fade-in" data-tipo="' . $conta['Tipo'] . '">';
+                echo '  <div class="account-card__header">';
+                echo '      <div class="flex items-center gap-2">';
+                echo '          <div class="account-card__icon"><i class="fas ' . $icone . '"></i></div>';
+                echo '          <h5 class="account-card__title">' . htmlspecialchars($conta['Nome']) . '</h5>';
+                echo '      </div>';
+                echo '      <span class="badge ' . $tipoBadgeClass . '">' . htmlspecialchars($conta['Tipo']) . '</span>';
+                echo '  </div>';
+                echo '  <div class="account-card__balance">R$ ' . number_format($conta['Saldo'], 2, ',', '.') . '</div>';
+                echo '  <div class="account-card__info">' . htmlspecialchars($conta['Instituicao']) . '</div>';
+                echo '  <div class="account-card__actions">';
+                echo '      <button class="btn-action edit" title="Editar" data-modal-open="#editarContaModal" ';
+                echo '          data-id="' . $conta['ID_Conta'] . '" ';
+                echo '          data-nome="' . htmlspecialchars($conta['Nome']) . '" ';
+                echo '          data-tipo="' . $conta['Tipo'] . '" ';
+                echo '          data-saldo="' . $conta['Saldo'] . '" ';
+                echo '          data-instituicao="' . htmlspecialchars($conta['Instituicao']) . '">';
+                echo '          <i class="fas fa-edit"></i>';
+                echo '      </button>';
+                echo '      <button class="btn-action delete" title="Excluir" data-modal-open="#excluirContaModal" ';
+                echo '          data-id="' . $conta['ID_Conta'] . '" ';
+                echo '          data-nome="' . htmlspecialchars($conta['Nome']) . '">';
+                echo '          <i class="fas fa-trash-alt"></i>';
+                echo '      </button>';
+                echo '  </div>';
+                echo '</div>';
+
+                $delay += 100;
             }
-            ?>
-        </tbody>
-    </table>
+        }
+        ?>
+    </div>
 </div>
 
 <script>
@@ -230,7 +195,8 @@ $count = count($contas);
     document.addEventListener('DOMContentLoaded', function () {
         const toggleBtn = document.getElementById('toggleFilter');
         const filterContent = document.querySelector('.filter-content');
-
+    });
+</script>
 <script src="contas.js"></script>
 
 <?php require_once 'footer.php'; ?>


### PR DESCRIPTION
## Summary
- ajusta variáveis de cor do tema
- adiciona efeitos em `.account-card`
- cria ações para os cards
- exibe contas como cards em 3 colunas

## Testing
- `php -l pages/contas.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479ef93f7883309a631eb04cc011fd