### PR TITLE
Fix edit modal data population

### DIFF
--- a/pages/contas/modal/modal.js
+++ b/pages/contas/modal/modal.js
@@ -105,7 +105,8 @@ document.addEventListener('DOMContentLoaded', function() {
         // Fill form fields
         document.getElementById('editarContaId').value = id;
         document.getElementById('editarNomeConta').value = nome;
-        document.getElementById('editarTipoConta').value = tipo;
+        // Preenche o campo oculto que armazena o tipo da conta
+        document.getElementById('editarTipoContaHidden').value = tipo;
         document.getElementById('editarSaldoConta').value = saldo;
         document.getElementById('editarInstituicaoConta').value = instituicao;
         

--- a/pages/transacoes/modal/modal.js
+++ b/pages/transacoes/modal/modal.js
@@ -224,47 +224,49 @@ document.addEventListener('DOMContentLoaded', function() {
           const contaDestinataria = this.getAttribute('data-conta-destinataria');
           const categoria = this.getAttribute('data-categoria');
           const formaPagamento = this.getAttribute('data-forma-pagamento');
-          
-          // Fill form fields
+
+          // Basic fields
           document.getElementById('editarTransacaoId').value = id;
           document.getElementById('editarTituloTransacao').value = titulo;
           document.getElementById('editarDescricaoTransacao').value = descricao;
           document.getElementById('editarValorTransacao').value = valor;
           document.getElementById('editarDataTransacao').value = data;
-          document.getElementById('editarTipoTransacao').value = tipo;
-          document.getElementById('editarStatusTransacao').value = status;
-          
-          if (document.getElementById('editarContaRemetente')) {
-            document.getElementById('editarContaRemetente').value = contaRemetente;
-          }
-          
-          if (document.getElementById('editarContaDestinataria')) {
-            document.getElementById('editarContaDestinataria').value = contaDestinataria;
-          }
-          
-          if (document.getElementById('editarCategoriaTransacao')) {
-            document.getElementById('editarCategoriaTransacao').value = categoria;
-          }
-          
-          if (document.getElementById('editarFormaPagamento')) {
-            document.getElementById('editarFormaPagamento').value = formaPagamento;
-          }
-          
-          // Trigger UI updates
+
+          // Trigger UI updates first so default handlers don't overwrite values
           const typeOption = document.querySelector(`#editarTransacaoModal .type-option[data-type="${tipo}"]`);
           if (typeOption) {
             typeOption.click();
           }
-          
+
           const statusOption = document.querySelector(`#editarTransacaoModal .status-option[data-status="${status}"]`);
           if (statusOption) {
             statusOption.click();
           }
-          
-          // Update all input states for floating labels
+
+          // Now set values that may be reset by the click handlers
+          document.getElementById('editarTipoTransacao').value = tipo;
+          document.getElementById('editarStatusTransacao').value = status;
+
+          if (document.getElementById('editarContaRemetente')) {
+            document.getElementById('editarContaRemetente').value = contaRemetente;
+          }
+
+          if (document.getElementById('editarContaDestinataria')) {
+            document.getElementById('editarContaDestinataria').value = contaDestinataria;
+          }
+
+          if (document.getElementById('editarCategoriaTransacao')) {
+            document.getElementById('editarCategoriaTransacao').value = categoria;
+          }
+
+          if (document.getElementById('editarFormaPagamento')) {
+            document.getElementById('editarFormaPagamento').value = formaPagamento;
+          }
+
+          // Update floating labels after setting values
           setupFloatingLabels();
-          
-          // Add entrance animation
+
+          // Entrance animation
           animateFields();
         });
       });


### PR DESCRIPTION
## Summary
- ensure edit transaction modal doesn't reset account and category fields

## Testing
- `node --check pages/transacoes/modal/modal.js`


------
https://chatgpt.com/codex/tasks/task_e_68496848569483308f0be070d7f7a394