### PR TITLE
Validate transaction value as positive

### DIFF
--- a/pages/transacoes/funcoes.php
+++ b/pages/transacoes/funcoes.php
@@ -168,6 +168,9 @@ function cadastrarTransacao($id_usuario, $titulo, $descricao, $valor, $formaPaga
         return false;
     }
 
+    // Converte o valor para float e garante que seja positivo
+    $valor = abs(floatval($valor));
+
     // Converte os valores para inteiros
     $idContaRemetente = intval($idContaRemetente);
     $idContaDestinataria = !empty($idContaDestinataria) ? intval($idContaDestinataria) : null;
@@ -269,7 +272,10 @@ function cadastrarTransacao($id_usuario, $titulo, $descricao, $valor, $formaPaga
 
 function editarTransacao($ID_Usuario, $titulo, $descricao, $valor, $data, $tipo, $status, $idCategoria, $ID_ContaRemetente, $ID_ContaDestinataria, $ID_Transacao) {
     global $conn;
-    $sql = "UPDATE TRANSACAO SET Titulo = ?, Descricao = ?, Valor = ?, Data = ?, Tipo = ?, Status = ?, ID_Categoria = ?, ID_ContaDestinataria = ?, ID_ContaRemetente = ?, ID_Usuario = ? 
+
+    // Garante que o valor seja tratado como positivo
+    $valor = abs(floatval($valor));
+    $sql = "UPDATE TRANSACAO SET Titulo = ?, Descricao = ?, Valor = ?, Data = ?, Tipo = ?, Status = ?, ID_Categoria = ?, ID_ContaDestinataria = ?, ID_ContaRemetente = ?, ID_Usuario = ?
             WHERE ID_Transacao = ?";
     $stmt = $conn->prepare($sql);
     $stmt->bind_param("ssdsssiiiii", $titulo, $descricao, $valor, $data, $tipo, $status, $idCategoria, $ID_ContaDestinataria, $ID_ContaRemetente, $ID_Usuario, $ID_Transacao);

--- a/pages/transacoes/modal.php
+++ b/pages/transacoes/modal.php
@@ -297,7 +297,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
                         <!-- Valor da Transação -->
                         <div class="form-group value-container">
-                            <input type="number" class="form-control" id="valorTransacao" name="valorTransacao" step="0.01" placeholder=" " required>
+                            <input type="number" class="form-control" id="valorTransacao" name="valorTransacao" step="0.01" min="0.01" placeholder=" " required>
                             <label for="valorTransacao">Valor</label>
                         </div>
 
@@ -443,7 +443,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
                         <!-- Valor da Transação -->
                         <div class="form-group value-container">
-                            <input type="number" class="form-control" id="editarValorTransacao" name="valorTransacao" step="0.01" placeholder=" " required>
+                            <input type="number" class="form-control" id="editarValorTransacao" name="valorTransacao" step="0.01" min="0.01" placeholder=" " required>
                             <label for="editarValorTransacao">Valor</label>
                         </div>
 


### PR DESCRIPTION
## Summary
- ensure new and edited transactions save positive values only
- enforce minimum positive value in value inputs

## Testing
- `php -l pages/transacoes/funcoes.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b076da4948330b876f6adbc1dc602